### PR TITLE
np21w: Update to 0.83-rev93, add np21w-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## May 13, 2025
+
+- np21w
+    - Update to 0.38-rev93.
+- np21w-beta
+    - Add np21w-beta Version 0.38-rev94beta4.
+
 ## May 3, 2025
 
 - freedos-dos

--- a/bucket/np21w-beta.json
+++ b/bucket/np21w-beta.json
@@ -1,0 +1,48 @@
+{
+  "version": "0.86-rev94beta4",
+  "homepage": "https://simk98.github.io/np21w/index.html",
+  "license": "Freeware",
+  "description": "Neko Project 21/W, PC-9800 Series Emulator (beta version).",
+  "url": [
+    "https://drive.google.com/uc?export=download&id=1_yFssgugBFG8Mtk52bPeiDDsVTOmtp8M#np21w-0.86-rev94beta4.zip",
+    "https://drive.google.com/uc?export=download&id=1R7YK4YRZXO5_-owK4if8i_U4BsjTRJpw#/np2tool.zip",
+    "https://drive.google.com/uc?export=download&id=18KH-ZV6kCa0j0fg-4JHgSIQsiX8N6whE#/np21wtool.zip"
+  ],
+  "hash": [
+    "427233f4b12c500c65749e57016167f121aeb9abf2a3ee7fd4a167757d958e70",
+    "514ca4cbebaed7ddb0ac758581d6458e319dce8720864102aa9e5d88ead27d6f",
+    "8df293272e40fc8db84d2f174798620a276c0e86ea8c13168e90f403d2f06a7c"
+  ],
+  "extract_dir": [
+    "np21w-0.86-rev94beta4",
+    "",
+    ""
+  ],
+  "installer": {
+    "script": [
+      "$null = New-Item -ItemType File -Path \"${dir}\\bin\\np2w.ini\"",
+      "$null = New-Item -ItemType File -Path \"${dir}\\bin\\np2x64w.ini\"",
+      "$null = New-Item -ItemType File -Path \"${dir}\\bin\\np21w.ini\"",
+      "$null = New-Item -ItemType File -Path \"${dir}\\bin\\np21x64w.ini\""
+    ]
+  },
+  "persist": [
+    "bin\\np2w.ini",
+    "bin\\np2x64w.ini",
+    "bin\\np21w.ini",
+    "bin\\np21x64w.ini"
+  ],
+  "bin": [
+    "bin\\np21w.exe"
+  ],
+  "shortcuts": [
+    [
+      "bin\\np21w.exe",
+      "Neko Project 21W"
+    ],
+    [
+      "bin\\np21x64w.exe",
+      "Neko Project 21W (x64)"
+    ]
+  ]
+}

--- a/bucket/np21w.json
+++ b/bucket/np21w.json
@@ -1,24 +1,20 @@
 {
-  "description": "Neko Project 21/W",
-  "homepage": "https://simk98.github.io/np21w/download.html",
-  "version": "0.86R91",
-  "license": [
-    {
-      "identifier": "Freeware"
-    }
-  ],
+  "version": "0.86-rev93",
+  "homepage": "https://simk98.github.io/np21w/index.html",
+  "license": "Freeware",
+  "description": "Neko Project 21/W, PC-9800 Series Emulator.",
   "url": [
-    "https://drive.google.com/uc?export=download&id=1MdufmeDVGe5N9WuL7wkLuXZY2FHRrmoQ#/np21w-0.86-rev91.zip",
+    "https://drive.google.com/uc?export=download&id=1rx5qw8OD5aAo6_Po0wPZkJGsPQWZD39G#/np21w-0.86-rev93.zip",
     "https://drive.google.com/uc?export=download&id=1R7YK4YRZXO5_-owK4if8i_U4BsjTRJpw#/np2tool.zip",
     "https://drive.google.com/uc?export=download&id=18KH-ZV6kCa0j0fg-4JHgSIQsiX8N6whE#/np21wtool.zip"
   ],
   "hash": [
-    "5cbc2e03600763b77aeb181de566dcce752e1471cb185e0f6143e1141910f553",
+    "4507ed04198704084aa2ace166e47f1027bcb4ad769a1bc7bc4f40dff45fd162",
     "514ca4cbebaed7ddb0ac758581d6458e319dce8720864102aa9e5d88ead27d6f",
     "8df293272e40fc8db84d2f174798620a276c0e86ea8c13168e90f403d2f06a7c"
   ],
   "extract_dir": [
-    "np21w-0.86-rev91",
+    "np21w-0.86-rev93",
     "",
     ""
   ],
@@ -36,14 +32,17 @@
     "bin\\np21w.ini",
     "bin\\np21x64w.ini"
   ],
+  "bin": [
+    "bin\\np21w.exe"
+  ],
   "shortcuts": [
     [
-      "bin\\np21x64w.exe",
-      "Neko Project 21／W"
+      "bin\\np21w.exe",
+      "Neko Project 21W"
     ],
     [
-      "bin\\np2x64w.exe",
-      "Neko Project Ⅱ／W"
+      "bin\\np21x64w.exe",
+      "Neko Project 21W (x64)"
     ]
   ]
 }


### PR DESCRIPTION
Like the title said, updating np21w to latest version. I also tried to follow your convention and feel free to edit my commit to your liking.

By the way, I think it's possible to add `autoupdate` by parsing [更新履歴](https://simk98.github.io/np21w/version.html) but did not succeed. Maybe you wanna try it.